### PR TITLE
doc97: Decrypt the `Data' stream as well.

### DIFF
--- a/msoffcrypto/format/doc97.py
+++ b/msoffcrypto/format/doc97.py
@@ -407,8 +407,20 @@ class Doc97File(base.BaseOfficeFile):
         obuf2.write(dec2.read())
         obuf2.seek(0)
 
+        obuf3 = None
+        if self.ole.exists('Data'):
+            obuf3 = io.BytesIO()
+            if self.type == "rc4":
+                dec3 = DocumentRC4.decrypt(self.key, self.salt, self.ole.openstream('Data'))
+            elif self.type == "rc4_cryptoapi":
+                dec3 = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, self.ole.openstream('Data'))
+            obuf3.write(dec3.read())
+            obuf3.seek(0)
+
         outole.write_stream('wordDocument', obuf1.read())
         outole.write_stream(self.info.tablename, obuf2.read())
+        if obuf3:
+            outole.write_stream('Data', obuf3.read())
 
         # _ofile = open(_ofile_path, 'rb')
 


### PR DESCRIPTION
According to the official documentation [1], the *Data* stream must be
encrypted and thus, decrypted as well. I tried with a doc file with
lots of pictures, when the *Data* stream is not decrypted, complaint
about corrupted data is made, and none of the pictures could be
viewed, on the other hand everything works fine if it's fully decrypted.

[1] https://msdn.microsoft.com/en-us/library/dd945648(v=office.12).aspx
    https://msdn.microsoft.com/en-us/library/dd946845(v=office.12).aspx