### PR TITLE
Unify setup.py name with package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 setup(
-    name='msoffcrypto-tool',
+    name='msoffcrypto',
     version=find_version("msoffcrypto", "__init__.py"),
     description='A Python tool and library for decrypting MS Office files with passwords or other keys',
     long_description=open("README.md", "r").read(),


### PR DESCRIPTION
It is unusual for name and package name to be different. This complicates building rpms, for example.