### PR TITLE
Fixed 9 issues of type: PYTHON_E401 throughout 8 files in repo.

### DIFF
--- a/msoffcrypto/__main__.py
+++ b/msoffcrypto/__main__.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import logging, sys
+import logging
+import sys
 import argparse
 
 import olefile
@@ -13,7 +14,8 @@ logger.addHandler(logging.NullHandler())
 
 def ifWIN32SetBinary(io):
     if sys.platform == 'win32':
-        import msvcrt, os
+        import msvcrt
+        import os
         msvcrt.setmode(io.fileno(), os.O_BINARY)
 
 

--- a/msoffcrypto/format/doc97.py
+++ b/msoffcrypto/format/doc97.py
@@ -1,4 +1,7 @@
-import logging, io, shutil, tempfile
+import logging
+import io
+import shutil
+import tempfile
 from struct import pack, unpack, unpack_from
 from collections import namedtuple
 

--- a/msoffcrypto/format/ooxml.py
+++ b/msoffcrypto/format/ooxml.py
@@ -1,5 +1,6 @@
 import logging
-import base64, io
+import base64
+import io
 from struct import unpack
 from xml.dom.minidom import parseString
 import zipfile

--- a/msoffcrypto/format/ppt97.py
+++ b/msoffcrypto/format/ppt97.py
@@ -1,4 +1,7 @@
-import logging, io, shutil, tempfile
+import logging
+import io
+import shutil
+import tempfile
 from struct import pack, unpack
 from collections import namedtuple
 

--- a/msoffcrypto/format/xls97.py
+++ b/msoffcrypto/format/xls97.py
@@ -1,4 +1,7 @@
-import logging, io, shutil, tempfile
+import logging
+import io
+import shutil
+import tempfile
 from struct import pack, unpack
 from collections import namedtuple
 

--- a/msoffcrypto/method/ecma376_agile.py
+++ b/msoffcrypto/method/ecma376_agile.py
@@ -1,5 +1,7 @@
 import logging
-import hashlib, functools, io
+import hashlib
+import functools
+import io
 from struct import pack, unpack
 
 from cryptography.hazmat.backends import default_backend

--- a/msoffcrypto/method/rc4.py
+++ b/msoffcrypto/method/rc4.py
@@ -1,4 +1,6 @@
-import functools, io, logging
+import functools
+import io
+import logging
 from hashlib import md5
 from struct import pack
 

--- a/msoffcrypto/method/rc4_cryptoapi.py
+++ b/msoffcrypto/method/rc4_cryptoapi.py
@@ -1,4 +1,6 @@
-import functools, io, logging
+import functools
+import io
+import logging
 from hashlib import sha1
 from struct import pack
 


### PR DESCRIPTION
PYTHON_E401: 'multiple imports on one line'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.