### PR TITLE
Fixed 1 issue of type: PYTHON_W291 throughout 1 file in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ],
     tests_require=[
         'nose >= 1.3.7',
-        'coverage >= 4.5.1', 
+        'coverage >= 4.5.1',
     ],
     classifiers=[
     ],


### PR DESCRIPTION
PYTHON_W291: 'Remove trailing whitespace.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.