### PR TITLE
Close ole and streams

### DIFF
--- a/msoffcrypto/__init__.py
+++ b/msoffcrypto/__init__.py
@@ -15,10 +15,15 @@ def OfficeFile(file):
         BaseOfficeFile object.
 
     Examples:
+        >>> # would be better but doctest cannot handle it:
+        >>> # with open(...) as f:
+        >>> #     officefile = OfficeFile(f)
+        >>> #     ...
         >>> f = open("tests/inputs/example_password.docx", "rb")
         >>> officefile = OfficeFile(f)
         >>> officefile.keyTypes
         ('password', 'private_key', 'secret_key')
+        >>> f.close()
     '''
     if olefile.isOleFile(file):
         ole = olefile.OleFileIO(file)

--- a/msoffcrypto/__init__.py
+++ b/msoffcrypto/__init__.py
@@ -15,15 +15,10 @@ def OfficeFile(file):
         BaseOfficeFile object.
 
     Examples:
-        >>> # would be better but doctest cannot handle it:
-        >>> # with open(...) as f:
-        >>> #     officefile = OfficeFile(f)
-        >>> #     ...
-        >>> f = open("tests/inputs/example_password.docx", "rb")
-        >>> officefile = OfficeFile(f)
-        >>> officefile.keyTypes
+        >>> with open("tests/inputs/example_password.docx", "rb") as f:
+        ...     officefile = OfficeFile(f)
+        ...     officefile.keyTypes
         ('password', 'private_key', 'secret_key')
-        >>> f.close()
     '''
     if olefile.isOleFile(file):
         ole = olefile.OleFileIO(file)

--- a/msoffcrypto/format/doc97.py
+++ b/msoffcrypto/format/doc97.py
@@ -343,89 +343,89 @@ class Doc97File(base.BaseOfficeFile):
         # shutil.copyfile(os.path.realpath(self.file.name), _ofile_path)
         # outole = olefile.OleFileIO(_ofile_path, write_mode=True)
 
+        obuf1 = io.BytesIO()
+        fibbase = FibBase(
+            wIdent=self.info.fib.base.wIdent,
+            nFib=self.info.fib.base.nFib,
+            unused=self.info.fib.base.unused,
+            lid=self.info.fib.base.lid,
+            pnNext=self.info.fib.base.pnNext,
+            fDot=self.info.fib.base.fDot,
+            fGlsy=self.info.fib.base.fGlsy,
+            fComplex=self.info.fib.base.fComplex,
+            fHasPic=self.info.fib.base.fHasPic,
+            cQuickSaves=self.info.fib.base.cQuickSaves,
+            fEncrypted=0,
+            fWhichTblStm=self.info.fib.base.fWhichTblStm,
+            fReadOnlyRecommended=self.info.fib.base.fReadOnlyRecommended,
+            fWriteReservation=self.info.fib.base.fWriteReservation,
+            fExtChar=self.info.fib.base.fExtChar,
+            fLoadOverride=self.info.fib.base.fLoadOverride,
+            fFarEast=self.info.fib.base.fFarEast,
+            nFibBack=self.info.fib.base.nFibBack,
+            fObfuscation=0,
+            IKey=0,
+            envr=self.info.fib.base.envr,
+            fMac=self.info.fib.base.fMac,
+            fEmptySpecial=self.info.fib.base.fEmptySpecial,
+            fLoadOverridePage=self.info.fib.base.fLoadOverridePage,
+            reserved1=self.info.fib.base.reserved1,
+            reserved2=self.info.fib.base.reserved2,
+            fSpare0=self.info.fib.base.fSpare0,
+            reserved3=self.info.fib.base.reserved3,
+            reserved4=self.info.fib.base.reserved4,
+            reserved5=self.info.fib.base.reserved5,
+            reserved6=self.info.fib.base.reserved6,
+        )
+        FIB_LENGTH = 0x44
+
+        header = _packFibBase(fibbase).read()
+        logger.debug(len(header))
+        obuf1.seek(0)
+        obuf1.write(header)
+
+        with self.ole.openstream('wordDocument') as worddocument:
+            worddocument.seek(len(header))
+            header = worddocument.read(FIB_LENGTH - len(header))
+            worddocument.seek(0)
+            logger.debug(len(header))
+            obuf1.write(header)
+
+            if self.type == "rc4":
+                dec1 = DocumentRC4.decrypt(self.key, self.salt, worddocument)
+            elif self.type == "rc4_cryptoapi":
+                dec1 = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, worddocument)
+            dec1.seek(FIB_LENGTH)
+            obuf1.write(dec1.read())
+            obuf1.seek(0)
+
+        # TODO: Preserve header
+        obuf2 = io.BytesIO()
+        if self.type == "rc4":
+            with self.ole.openstream(self.info.tablename) as stream:
+                dec2 = DocumentRC4.decrypt(self.key, self.salt, stream)
+        elif self.type == "rc4_cryptoapi":
+            with self.ole.openstream(self.info.tablename) as stream:
+                dec2 = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, stream)
+        obuf2.write(dec2.read())
+        obuf2.seek(0)
+
+        obuf3 = None
+        if self.ole.exists('Data'):
+            obuf3 = io.BytesIO()
+            if self.type == "rc4":
+                with self.ole.openstream('Data') as data_stream:
+                    dec3 = DocumentRC4.decrypt(self.key, self.salt, data_stream)
+            elif self.type == "rc4_cryptoapi":
+                with self.ole.openstream('Data') as data_stream:
+                    dec3 = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, data_stream)
+            obuf3.write(dec3.read())
+            obuf3.seek(0)
+
         with tempfile.TemporaryFile() as _ofile:
             self.file.seek(0)
             shutil.copyfileobj(self.file, _ofile)
             outole = olefile.OleFileIO(_ofile, write_mode=True)
-
-            obuf1 = io.BytesIO()
-            fibbase = FibBase(
-                wIdent=self.info.fib.base.wIdent,
-                nFib=self.info.fib.base.nFib,
-                unused=self.info.fib.base.unused,
-                lid=self.info.fib.base.lid,
-                pnNext=self.info.fib.base.pnNext,
-                fDot=self.info.fib.base.fDot,
-                fGlsy=self.info.fib.base.fGlsy,
-                fComplex=self.info.fib.base.fComplex,
-                fHasPic=self.info.fib.base.fHasPic,
-                cQuickSaves=self.info.fib.base.cQuickSaves,
-                fEncrypted=0,
-                fWhichTblStm=self.info.fib.base.fWhichTblStm,
-                fReadOnlyRecommended=self.info.fib.base.fReadOnlyRecommended,
-                fWriteReservation=self.info.fib.base.fWriteReservation,
-                fExtChar=self.info.fib.base.fExtChar,
-                fLoadOverride=self.info.fib.base.fLoadOverride,
-                fFarEast=self.info.fib.base.fFarEast,
-                nFibBack=self.info.fib.base.nFibBack,
-                fObfuscation=0,
-                IKey=0,
-                envr=self.info.fib.base.envr,
-                fMac=self.info.fib.base.fMac,
-                fEmptySpecial=self.info.fib.base.fEmptySpecial,
-                fLoadOverridePage=self.info.fib.base.fLoadOverridePage,
-                reserved1=self.info.fib.base.reserved1,
-                reserved2=self.info.fib.base.reserved2,
-                fSpare0=self.info.fib.base.fSpare0,
-                reserved3=self.info.fib.base.reserved3,
-                reserved4=self.info.fib.base.reserved4,
-                reserved5=self.info.fib.base.reserved5,
-                reserved6=self.info.fib.base.reserved6,
-            )
-            FIB_LENGTH = 0x44
-
-            header = _packFibBase(fibbase).read()
-            logger.debug(len(header))
-            obuf1.seek(0)
-            obuf1.write(header)
-
-            with self.ole.openstream('wordDocument') as worddocument:
-                worddocument.seek(len(header))
-                header = worddocument.read(FIB_LENGTH - len(header))
-                worddocument.seek(0)
-                logger.debug(len(header))
-                obuf1.write(header)
-
-                if self.type == "rc4":
-                    dec1 = DocumentRC4.decrypt(self.key, self.salt, worddocument)
-                elif self.type == "rc4_cryptoapi":
-                    dec1 = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, worddocument)
-                dec1.seek(FIB_LENGTH)
-                obuf1.write(dec1.read())
-                obuf1.seek(0)
-
-            # TODO: Preserve header
-            obuf2 = io.BytesIO()
-            if self.type == "rc4":
-                with self.ole.openstream(self.info.tablename) as stream:
-                    dec2 = DocumentRC4.decrypt(self.key, self.salt, stream)
-            elif self.type == "rc4_cryptoapi":
-                with self.ole.openstream(self.info.tablename) as stream:
-                    dec2 = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, stream)
-            obuf2.write(dec2.read())
-            obuf2.seek(0)
-
-            obuf3 = None
-            if self.ole.exists('Data'):
-                obuf3 = io.BytesIO()
-                if self.type == "rc4":
-                    with self.ole.openstream('Data') as data_stream:
-                        dec3 = DocumentRC4.decrypt(self.key, self.salt, data_stream)
-                elif self.type == "rc4_cryptoapi":
-                    with self.ole.openstream('Data') as data_stream:
-                        dec3 = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, data_stream)
-                obuf3.write(dec3.read())
-                obuf3.seek(0)
 
             outole.write_stream('wordDocument', obuf1.read())
             outole.write_stream(self.info.tablename, obuf2.read())

--- a/msoffcrypto/format/doc97.py
+++ b/msoffcrypto/format/doc97.py
@@ -312,7 +312,7 @@ class Doc97File(base.BaseOfficeFile):
                 encryptionHeader_size = fib.base.IKey
                 logger.debug("encryptionHeader_size: {}".format(hex(encryptionHeader_size)))
                 with self.ole.openstream(self.info.tablename) as table:
-                    encryptionHeader = table
+                    encryptionHeader = table          # TODO why create a 2nd reference to same stream?
                     encryptionVersionInfo = table.read(4)
                     vMajor, vMinor = unpack("<HH", encryptionVersionInfo)
                     logger.debug("Version: {} {}".format(vMajor, vMinor))

--- a/msoffcrypto/format/ooxml.py
+++ b/msoffcrypto/format/ooxml.py
@@ -75,6 +75,7 @@ class OOXMLFile(base.BaseOfficeFile):
         file.seek(0)  # TODO: Investigate the effect (required for olefile.isOleFile)
         self.close_file_in_destructor = False
         # olefile cannot process non password protected ooxml files.
+        # TODO: this code is duplicate of OfficeFile(). Merge?
         if olefile.isOleFile(file):
             ole = olefile.OleFileIO(file)
             self.file = ole

--- a/msoffcrypto/format/ppt97.py
+++ b/msoffcrypto/format/ppt97.py
@@ -558,179 +558,179 @@ class Ppt97File(base.BaseOfficeFile):
             raise Exception("Failed to verify password")
 
     def decrypt(self, ofile):
-        _ofile = tempfile.TemporaryFile()
-        self.file.seek(0)
-        shutil.copyfileobj(self.file, _ofile)
-        outole = olefile.OleFileIO(_ofile, write_mode=True)
+        with tempfile.TemporaryFile() as _ofile:
+            self.file.seek(0)
+            shutil.copyfileobj(self.file, _ofile)
+            outole = olefile.OleFileIO(_ofile, write_mode=True)
 
-        # Current User Stream
-        self.data.currentuser.seek(0)
-        currentuser = _parseCurrentUser(self.data.currentuser)
-        # logger.debug(currentuser)
+            # Current User Stream
+            self.data.currentuser.seek(0)
+            currentuser = _parseCurrentUser(self.data.currentuser)
+            # logger.debug(currentuser)
 
-        cuatom = currentuser.currentuseratom
+            cuatom = currentuser.currentuseratom
 
-        currentuser_new = CurrentUser(
-            currentuseratom=CurrentUserAtom(
-                rh=cuatom.rh,
-                size=cuatom.size,
-                # https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-ppt/940d5700-e4d7-4fc0-ab48-fed5dbc48bc1
-                # 0xE391C05F: The file SHOULD NOT<6> be an encrypted document.
-                headerToken=0xe391c05f,
-                offsetToCurrentEdit=cuatom.offsetToCurrentEdit,
-                lenUserName=cuatom.lenUserName,
-                docFileVersion=cuatom.docFileVersion,
-                majorVersion=cuatom.majorVersion,
-                minorVersion=cuatom.minorVersion,
-                unused=cuatom.unused,
-                ansiUserName=cuatom.ansiUserName,
-                relVersion=cuatom.relVersion,
-                unicodeUserName=cuatom.unicodeUserName,
+            currentuser_new = CurrentUser(
+                currentuseratom=CurrentUserAtom(
+                    rh=cuatom.rh,
+                    size=cuatom.size,
+                    # https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-ppt/940d5700-e4d7-4fc0-ab48-fed5dbc48bc1
+                    # 0xE391C05F: The file SHOULD NOT<6> be an encrypted document.
+                    headerToken=0xe391c05f,
+                    offsetToCurrentEdit=cuatom.offsetToCurrentEdit,
+                    lenUserName=cuatom.lenUserName,
+                    docFileVersion=cuatom.docFileVersion,
+                    majorVersion=cuatom.majorVersion,
+                    minorVersion=cuatom.minorVersion,
+                    unused=cuatom.unused,
+                    ansiUserName=cuatom.ansiUserName,
+                    relVersion=cuatom.relVersion,
+                    unicodeUserName=cuatom.unicodeUserName,
+                )
             )
-        )
 
-        buf = _packCurrentUser(currentuser_new)
-        buf.seek(0)
-        outole.write_stream('Current User', buf.read())
+            buf = _packCurrentUser(currentuser_new)
+            buf.seek(0)
+            outole.write_stream('Current User', buf.read())
 
-        # List of encrypted parts: https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-ppt/b0963334-4408-4621-879a-ef9c54551fd8
+            # List of encrypted parts: https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-ppt/b0963334-4408-4621-879a-ef9c54551fd8
 
-        # PowerPoint Document Stream
+            # PowerPoint Document Stream
 
-        self.data.powerpointdocument.seek(0)
-        powerpointdocument_size = len(self.data.powerpointdocument.read())
-        logger.debug("[*] powerpointdocument_size: {}".format(powerpointdocument_size))
+            self.data.powerpointdocument.seek(0)
+            powerpointdocument_size = len(self.data.powerpointdocument.read())
+            logger.debug("[*] powerpointdocument_size: {}".format(powerpointdocument_size))
 
-        self.data.powerpointdocument.seek(0)
-        dec_bytearray = bytearray(self.data.powerpointdocument.read())
+            self.data.powerpointdocument.seek(0)
+            dec_bytearray = bytearray(self.data.powerpointdocument.read())
 
-        # UserEditAtom
-        self.data.powerpointdocument.seek(currentuser.currentuseratom.offsetToCurrentEdit)
-        # currentuseratom_raw = self.data.powerpointdocument.read(40)
+            # UserEditAtom
+            self.data.powerpointdocument.seek(currentuser.currentuseratom.offsetToCurrentEdit)
+            # currentuseratom_raw = self.data.powerpointdocument.read(40)
 
-        self.data.powerpointdocument.seek(currentuser.currentuseratom.offsetToCurrentEdit)
-        usereditatom = _parseUserEditAtom(self.data.powerpointdocument)
-        # logger.debug(usereditatom)
-        # logger.debug(["offsetToCurrentEdit", currentuser.currentuseratom.offsetToCurrentEdit])
+            self.data.powerpointdocument.seek(currentuser.currentuseratom.offsetToCurrentEdit)
+            usereditatom = _parseUserEditAtom(self.data.powerpointdocument)
+            # logger.debug(usereditatom)
+            # logger.debug(["offsetToCurrentEdit", currentuser.currentuseratom.offsetToCurrentEdit])
 
-        rh_new = RecordHeader(
-            recVer=usereditatom.rh.recVer,
-            recInstance=usereditatom.rh.recInstance,
-            recType=usereditatom.rh.recType,
-            recLen=usereditatom.rh.recLen - 4,  # Omit encryptSessionPersistIdRef field
-        )
+            rh_new = RecordHeader(
+                recVer=usereditatom.rh.recVer,
+                recInstance=usereditatom.rh.recInstance,
+                recType=usereditatom.rh.recType,
+                recLen=usereditatom.rh.recLen - 4,  # Omit encryptSessionPersistIdRef field
+            )
 
-        # logger.debug([_packRecordHeader(usereditatom.rh).read(), _packRecordHeader(rh_new).read()])
+            # logger.debug([_packRecordHeader(usereditatom.rh).read(), _packRecordHeader(rh_new).read()])
 
-        usereditatom_new = UserEditAtom(
-            rh=rh_new,
-            lastSlideIdRef=usereditatom.lastSlideIdRef,
-            version=usereditatom.version,
-            minorVersion=usereditatom.minorVersion,
-            majorVersion=usereditatom.majorVersion,
-            offsetLastEdit=usereditatom.offsetLastEdit,
-            offsetPersistDirectory=usereditatom.offsetPersistDirectory,
-            docPersistIdRef=usereditatom.docPersistIdRef,
-            persistIdSeed=usereditatom.persistIdSeed,
-            lastView=usereditatom.lastView,
-            unused=usereditatom.unused,
-            encryptSessionPersistIdRef=0x00000000,  # Clear
-        )
+            usereditatom_new = UserEditAtom(
+                rh=rh_new,
+                lastSlideIdRef=usereditatom.lastSlideIdRef,
+                version=usereditatom.version,
+                minorVersion=usereditatom.minorVersion,
+                majorVersion=usereditatom.majorVersion,
+                offsetLastEdit=usereditatom.offsetLastEdit,
+                offsetPersistDirectory=usereditatom.offsetPersistDirectory,
+                docPersistIdRef=usereditatom.docPersistIdRef,
+                persistIdSeed=usereditatom.persistIdSeed,
+                lastView=usereditatom.lastView,
+                unused=usereditatom.unused,
+                encryptSessionPersistIdRef=0x00000000,  # Clear
+            )
 
-        # logger.debug(currentuseratom_raw)
-        # logger.debug(_packUserEditAtom(usereditatom).read())
-        # logger.debug(_packUserEditAtom(usereditatom_new).read())
+            # logger.debug(currentuseratom_raw)
+            # logger.debug(_packUserEditAtom(usereditatom).read())
+            # logger.debug(_packUserEditAtom(usereditatom_new).read())
 
-        buf = _packUserEditAtom(usereditatom_new)
-        buf.seek(0)
-        buf_bytes = bytearray(buf.read())
-        offset = currentuser.currentuseratom.offsetToCurrentEdit
-        dec_bytearray[offset:offset+len(buf_bytes)] = buf_bytes
+            buf = _packUserEditAtom(usereditatom_new)
+            buf.seek(0)
+            buf_bytes = bytearray(buf.read())
+            offset = currentuser.currentuseratom.offsetToCurrentEdit
+            dec_bytearray[offset:offset+len(buf_bytes)] = buf_bytes
 
-        # PersistDirectoryAtom
-        self.data.powerpointdocument.seek(currentuser.currentuseratom.offsetToCurrentEdit)
-        usereditatom = _parseUserEditAtom(self.data.powerpointdocument)
-        # logger.debug(usereditatom)
+            # PersistDirectoryAtom
+            self.data.powerpointdocument.seek(currentuser.currentuseratom.offsetToCurrentEdit)
+            usereditatom = _parseUserEditAtom(self.data.powerpointdocument)
+            # logger.debug(usereditatom)
 
-        self.data.powerpointdocument.seek(usereditatom.offsetPersistDirectory)
-        persistdirectoryatom = _parsePersistDirectoryAtom(self.data.powerpointdocument)
-        # logger.debug(persistdirectoryatom)
+            self.data.powerpointdocument.seek(usereditatom.offsetPersistDirectory)
+            persistdirectoryatom = _parsePersistDirectoryAtom(self.data.powerpointdocument)
+            # logger.debug(persistdirectoryatom)
 
-        persistdirectoryatom_new = PersistDirectoryAtom(
-            rh=persistdirectoryatom.rh,
-            rgPersistDirEntry=[
-                PersistDirectoryEntry(
-                    persistId=persistdirectoryatom.rgPersistDirEntry[0].persistId,
-                    # Omit CryptSession10Container
-                    cPersist=persistdirectoryatom.rgPersistDirEntry[0].cPersist-1,
-                    rgPersistOffset=persistdirectoryatom.rgPersistDirEntry[0].rgPersistOffset,
-                ),
-            ],
-        )
+            persistdirectoryatom_new = PersistDirectoryAtom(
+                rh=persistdirectoryatom.rh,
+                rgPersistDirEntry=[
+                    PersistDirectoryEntry(
+                        persistId=persistdirectoryatom.rgPersistDirEntry[0].persistId,
+                        # Omit CryptSession10Container
+                        cPersist=persistdirectoryatom.rgPersistDirEntry[0].cPersist-1,
+                        rgPersistOffset=persistdirectoryatom.rgPersistDirEntry[0].rgPersistOffset,
+                    ),
+                ],
+            )
 
-        self.data.powerpointdocument.seek(usereditatom.offsetPersistDirectory)
-        buf = _packPersistDirectoryAtom(persistdirectoryatom_new)
-        buf_bytes = bytearray(buf.read())
-        offset = usereditatom.offsetPersistDirectory
-        dec_bytearray[offset:offset+len(buf_bytes)] = buf_bytes
+            self.data.powerpointdocument.seek(usereditatom.offsetPersistDirectory)
+            buf = _packPersistDirectoryAtom(persistdirectoryatom_new)
+            buf_bytes = bytearray(buf.read())
+            offset = usereditatom.offsetPersistDirectory
+            dec_bytearray[offset:offset+len(buf_bytes)] = buf_bytes
 
-        # Persist Objects
-        self.data.powerpointdocument.seek(0)
-        persistobjectdirectory = construct_persistobjectdirectory(self.data)
+            # Persist Objects
+            self.data.powerpointdocument.seek(0)
+            persistobjectdirectory = construct_persistobjectdirectory(self.data)
 
-        directory_items = list(persistobjectdirectory.items())
+            directory_items = list(persistobjectdirectory.items())
 
-        for i, (persistId, offset) in enumerate(directory_items):
-            self.data.powerpointdocument.seek(offset)
-            buf = self.data.powerpointdocument.read(8)
-            rh = _parseRecordHeader(io.BytesIO(buf))
-            logger.debug("[*] rh: {}".format(rh))
+            for i, (persistId, offset) in enumerate(directory_items):
+                self.data.powerpointdocument.seek(offset)
+                buf = self.data.powerpointdocument.read(8)
+                rh = _parseRecordHeader(io.BytesIO(buf))
+                logger.debug("[*] rh: {}".format(rh))
 
-            # CryptSession10Container
-            if rh.recType == 0x2f14:
-                logger.debug("[*] CryptSession10Container found")
-                # Remove encryption, pad by zero to preserve stream size
-                dec_bytearray[offset:offset+(8+rh.recLen)] = b"\x00" * (8+rh.recLen)
-                continue
+                # CryptSession10Container
+                if rh.recType == 0x2f14:
+                    logger.debug("[*] CryptSession10Container found")
+                    # Remove encryption, pad by zero to preserve stream size
+                    dec_bytearray[offset:offset+(8+rh.recLen)] = b"\x00" * (8+rh.recLen)
+                    continue
 
-            # The UserEditAtom record (section 2.3.3) and the PersistDirectoryAtom record (section 2.3.4) MUST NOT be encrypted.
-            if rh.recType in [0x0ff5, 0x1772]:
-                logger.debug("[*] UserEditAtom/PersistDirectoryAtom found")
-                continue
+                # The UserEditAtom record (section 2.3.3) and the PersistDirectoryAtom record (section 2.3.4) MUST NOT be encrypted.
+                if rh.recType in [0x0ff5, 0x1772]:
+                    logger.debug("[*] UserEditAtom/PersistDirectoryAtom found")
+                    continue
 
-            # TODO: Fix here
-            recLen = directory_items[i+1][1] - offset - 8
-            logger.debug("[*] recLen: {}".format(recLen))
+                # TODO: Fix here
+                recLen = directory_items[i+1][1] - offset - 8
+                logger.debug("[*] recLen: {}".format(recLen))
 
-            self.data.powerpointdocument.seek(offset)
-            enc_buf = io.BytesIO(self.data.powerpointdocument.read(8+recLen))
-            blocksize = self.keySize * ((8 + recLen) // self.keySize + 1)  # Undocumented
-            dec = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, enc_buf, blocksize=blocksize, block=persistId)
-            dec_bytes = bytearray(dec.read())
-            dec_bytearray[offset:offset+len(dec_bytes)] = dec_bytes
+                self.data.powerpointdocument.seek(offset)
+                enc_buf = io.BytesIO(self.data.powerpointdocument.read(8+recLen))
+                blocksize = self.keySize * ((8 + recLen) // self.keySize + 1)  # Undocumented
+                dec = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, enc_buf, blocksize=blocksize, block=persistId)
+                dec_bytes = bytearray(dec.read())
+                dec_bytearray[offset:offset+len(dec_bytes)] = dec_bytes
 
-        # To BytesIO
-        dec_buf = io.BytesIO(dec_bytearray)
+            # To BytesIO
+            dec_buf = io.BytesIO(dec_bytearray)
 
-        dec_buf.seek(0)
-        for i, (persistId, offset) in enumerate(directory_items):
-            dec_buf.seek(offset)
-            buf = dec_buf.read(8)
-            rh = _parseRecordHeader(io.BytesIO(buf))
-            logger.debug("[*] rh: {}".format(rh))
+            dec_buf.seek(0)
+            for i, (persistId, offset) in enumerate(directory_items):
+                dec_buf.seek(offset)
+                buf = dec_buf.read(8)
+                rh = _parseRecordHeader(io.BytesIO(buf))
+                logger.debug("[*] rh: {}".format(rh))
 
-        dec_buf.seek(0)
-        logger.debug("[*] powerpointdocument_size={}, len(dec_buf.read())={}".format(powerpointdocument_size, len(dec_buf.read())))
+            dec_buf.seek(0)
+            logger.debug("[*] powerpointdocument_size={}, len(dec_buf.read())={}".format(powerpointdocument_size, len(dec_buf.read())))
 
-        dec_buf.seek(0)
-        outole.write_stream('PowerPoint Document', dec_buf.read())
+            dec_buf.seek(0)
+            outole.write_stream('PowerPoint Document', dec_buf.read())
 
-        # TODO: Pictures Stream
-        # TODO: Encrypted Summary Info Stream
+            # TODO: Pictures Stream
+            # TODO: Encrypted Summary Info Stream
 
-        # Finalize
-        _ofile.seek(0)
-        shutil.copyfileobj(_ofile, ofile)
+            # Finalize
+            _ofile.seek(0)
+            shutil.copyfileobj(_ofile, ofile)
 
         return
 

--- a/msoffcrypto/format/xls97.py
+++ b/msoffcrypto/format/xls97.py
@@ -544,8 +544,8 @@ class Xls97File(base.BaseOfficeFile):
             # FilePass (section 2.4.117), UsrExcl (section 2.4.339), FileLock (section 2.4.116),
             # InterfaceHdr (section 2.4.146), RRDInfo (section 2.4.227), and RRDHead (section 2.4.226).
             elif num in [recordNameNum['BOF'], recordNameNum['FilePass'], recordNameNum['UsrExcl'],
-                            recordNameNum['FileLock'], recordNameNum['InterfaceHdr'], recordNameNum['RRDInfo'],
-                            recordNameNum['RRDHead']]:
+                         recordNameNum['FileLock'], recordNameNum['InterfaceHdr'], recordNameNum['RRDInfo'],
+                         recordNameNum['RRDHead']]:
                 header = pack("<HH", num, size)
                 plain_buf += list(header) + list(record.read())
                 encrypted_buf.write(b"\x00"*(4+size))

--- a/msoffcrypto/format/xls97.py
+++ b/msoffcrypto/format/xls97.py
@@ -526,64 +526,66 @@ class Xls97File(base.BaseOfficeFile):
         # shutil.copyfile(os.path.realpath(self.file.name), _ofile_path)
         # outole = olefile.OleFileIO(_ofile_path, write_mode=True)
 
+        # List of encrypted parts: https://msdn.microsoft.com/en-us/library/dd905723(v=office.12).aspx
+
+        # Workbook stream
+        self.data.workbook.seek(0)
+        workbook = _BIFFStream(self.data.workbook)
+
+        plain_buf = []
+        encrypted_buf = io.BytesIO()
+
+        for i, (num, size, record) in enumerate(workbook.iter_record()):
+            # Remove encryption, pad by zero to preserve stream size
+            if num == recordNameNum['FilePass']:
+                plain_buf += [0, 0] + list(pack("<H", size)) + [0] * size
+                encrypted_buf.write(b"\x00"*(4+size))
+            # The following records MUST NOT be obfuscated or encrypted: BOF (section 2.4.21),
+            # FilePass (section 2.4.117), UsrExcl (section 2.4.339), FileLock (section 2.4.116),
+            # InterfaceHdr (section 2.4.146), RRDInfo (section 2.4.227), and RRDHead (section 2.4.226).
+            elif num in [recordNameNum['BOF'], recordNameNum['FilePass'], recordNameNum['UsrExcl'],
+                            recordNameNum['FileLock'], recordNameNum['InterfaceHdr'], recordNameNum['RRDInfo'],
+                            recordNameNum['RRDHead']]:
+                header = pack("<HH", num, size)
+                plain_buf += list(header) + list(record.read())
+                encrypted_buf.write(b"\x00"*(4+size))
+            # The lbPlyPos field of the BoundSheet8 record (section 2.4.28) MUST NOT be encrypted.
+            elif num == recordNameNum['BoundSheet8']:
+                header = pack("<HH", num, size)
+                plain_buf += list(header) + list(record.read(4)) + [-1] * (size-4)  # Preserve lbPlyPos
+                encrypted_buf.write(b"\x00"*4 + b"\x00"*4 + record.read())
+            else:
+                header = pack("<HH", num, size)
+                plain_buf += list(header) + [-1] * size
+                encrypted_buf.write(b"\x00"*4 + record.read())
+
+        encrypted_buf.seek(0)
+
+        if self.type == "rc4":
+            dec = DocumentRC4.decrypt(self.key, self.salt, encrypted_buf, blocksize=1024)
+        elif self.type == "rc4_cryptoapi":
+            dec = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, encrypted_buf, blocksize=1024)
+
+        for c in plain_buf:
+            if c == -1:
+                dec.seek(1, 1)
+            else:
+                dec.write(bytearray([c]))
+
+        dec.seek(0)
+
+        # f = open('Workbook', 'wb')
+        # f.write(dec.read())
+        # dec.seek(0)
+
+        workbook_dec = dec
+
         with tempfile.TemporaryFile() as _ofile:
             self.file.seek(0)
             shutil.copyfileobj(self.file, _ofile)
             outole = olefile.OleFileIO(_ofile, write_mode=True)
 
-            # List of encrypted parts: https://msdn.microsoft.com/en-us/library/dd905723(v=office.12).aspx
-
-            # Workbook stream
-            self.data.workbook.seek(0)
-            workbook = _BIFFStream(self.data.workbook)
-
-            plain_buf = []
-            encrypted_buf = io.BytesIO()
-
-            for i, (num, size, record) in enumerate(workbook.iter_record()):
-                # Remove encryption, pad by zero to preserve stream size
-                if num == recordNameNum['FilePass']:
-                    plain_buf += [0, 0] + list(pack("<H", size)) + [0] * size
-                    encrypted_buf.write(b"\x00"*(4+size))
-                # The following records MUST NOT be obfuscated or encrypted: BOF (section 2.4.21),
-                # FilePass (section 2.4.117), UsrExcl (section 2.4.339), FileLock (section 2.4.116),
-                # InterfaceHdr (section 2.4.146), RRDInfo (section 2.4.227), and RRDHead (section 2.4.226).
-                elif num in [recordNameNum['BOF'], recordNameNum['FilePass'], recordNameNum['UsrExcl'],
-                             recordNameNum['FileLock'], recordNameNum['InterfaceHdr'], recordNameNum['RRDInfo'],
-                             recordNameNum['RRDHead']]:
-                    header = pack("<HH", num, size)
-                    plain_buf += list(header) + list(record.read())
-                    encrypted_buf.write(b"\x00"*(4+size))
-                # The lbPlyPos field of the BoundSheet8 record (section 2.4.28) MUST NOT be encrypted.
-                elif num == recordNameNum['BoundSheet8']:
-                    header = pack("<HH", num, size)
-                    plain_buf += list(header) + list(record.read(4)) + [-1] * (size-4)  # Preserve lbPlyPos
-                    encrypted_buf.write(b"\x00"*4 + b"\x00"*4 + record.read())
-                else:
-                    header = pack("<HH", num, size)
-                    plain_buf += list(header) + [-1] * size
-                    encrypted_buf.write(b"\x00"*4 + record.read())
-
-            encrypted_buf.seek(0)
-
-            if self.type == "rc4":
-                dec = DocumentRC4.decrypt(self.key, self.salt, encrypted_buf, blocksize=1024)
-            elif self.type == "rc4_cryptoapi":
-                dec = DocumentRC4CryptoAPI.decrypt(self.key, self.salt, self.keySize, encrypted_buf, blocksize=1024)
-
-            for c in plain_buf:
-                if c == -1:
-                    dec.seek(1, 1)
-                else:
-                    dec.write(bytearray([c]))
-
-            dec.seek(0)
-
-            # f = open('Workbook', 'wb')
-            # f.write(dec.read())
-            # dec.seek(0)
-
-            outole.write_stream('Workbook', dec.read())
+            outole.write_stream('Workbook', workbook_dec.read())
 
             # _ofile = open(_ofile_path, 'rb')
 


### PR DESCRIPTION
Ensure all OleFileIO and all OleStreams and all TemporaryFiles are closed after use.

So far, there were quite a few "leaking" file objects, that were closed automatically only at the end of the python session. This resulted in "ResourceWarning: unclosed file ..."  when running the code in a new python (version >= 3.6 I believe)

Fixed most of these using with-statements. A few needed to be closed in destructors which is not quite as elegant and reliabe (not sure whether this always works in exception case).

At least the warnings are gone now.