### PR TITLE
Do not close given file

### DIFF
--- a/msoffcrypto/__init__.py
+++ b/msoffcrypto/__init__.py
@@ -20,6 +20,7 @@ def OfficeFile(file):
         ...     officefile.keyTypes
         ('password', 'private_key', 'secret_key')
     '''
+    file.seek(0)     # required by isOleFile
     if olefile.isOleFile(file):
         ole = olefile.OleFileIO(file)
     elif zipfile.is_zipfile(file):  # Heuristic

--- a/msoffcrypto/__init__.py
+++ b/msoffcrypto/__init__.py
@@ -19,6 +19,9 @@ def OfficeFile(file):
         ...     officefile = OfficeFile(f)
         ...     officefile.keyTypes
         ('password', 'private_key', 'secret_key')
+
+    Given file handle will not be closed, the file position will most certainly
+    change.
     '''
     file.seek(0)     # required by isOleFile
     if olefile.isOleFile(file):

--- a/msoffcrypto/format/doc97.py
+++ b/msoffcrypto/format/doc97.py
@@ -275,7 +275,7 @@ def _parse_header_RC4CryptoAPI(encryptionHeader):
 class Doc97File(base.BaseOfficeFile):
     def __init__(self, file):
         self.file = file
-        ole = olefile.OleFileIO(file)      # closed in destructor
+        ole = olefile.OleFileIO(file)  # do not close this, would close file
         self.ole = ole
         self.format = "doc97"
         self.keyTypes = ['password']
@@ -294,11 +294,6 @@ class Doc97File(base.BaseOfficeFile):
             fib=fib,
             tablename=tablename,
         )
-
-    def __del__(self):
-        """Destructor, closes opened olefile."""
-        if hasattr(self, 'ole') and self.ole:
-            self.ole.close()
 
     def load_key(self, password=None):
         fib = self.info.fib

--- a/msoffcrypto/format/ooxml.py
+++ b/msoffcrypto/format/ooxml.py
@@ -73,13 +73,11 @@ class OOXMLFile(base.BaseOfficeFile):
     def __init__(self, file):
         self.format = "ooxml"
         file.seek(0)  # TODO: Investigate the effect (required for olefile.isOleFile)
-        self.close_file_in_destructor = False
         # olefile cannot process non password protected ooxml files.
         # TODO: this code is duplicate of OfficeFile(). Merge?
         if olefile.isOleFile(file):
             ole = olefile.OleFileIO(file)
             self.file = ole
-            self.close_file_in_destructor = True
             with self.file.openstream('EncryptionInfo') as stream:
                 self.type, self.info = _parseinfo(stream)
             logger.debug("OOXMLFile.type: {}".format(self.type))
@@ -97,10 +95,6 @@ class OOXMLFile(base.BaseOfficeFile):
             self.secret_key = None
         else:
             raise Exception("Unsupported file format")
-
-    def __del__(self):
-        if self.close_file_in_destructor and self.file:
-            self.file.close()
 
     def load_key(self, password=None, private_key=None, secret_key=None, strict=False):
         if password:

--- a/msoffcrypto/format/ppt97.py
+++ b/msoffcrypto/format/ppt97.py
@@ -492,7 +492,7 @@ def _parse_header_RC4CryptoAPI(encryptionInfo):
 class Ppt97File(base.BaseOfficeFile):
     def __init__(self, file):
         self.file = file
-        ole = olefile.OleFileIO(file)    # closed in destructor
+        ole = olefile.OleFileIO(file)  # do not close this, would close file
         self.ole = ole
         self.format = "ppt97"
         self.keyTypes = ['password']
@@ -510,14 +510,12 @@ class Ppt97File(base.BaseOfficeFile):
         )
 
     def __del__(self):
-        """Destructor, closes opened olefile and streams."""
+        """Destructor, closes opened streams."""
         if hasattr(self, 'data') and self.data:
             if self.data.currentuser:
                 self.data.currentuser.close()
             if self.data.powerpointdocument:
                 self.data.powerpointdocument.close()
-        if hasattr(self, 'ole') and self.ole:
-            self.ole.close()
 
     def load_key(self, password=None):
         persistobjectdirectory = construct_persistobjectdirectory(self.data)

--- a/msoffcrypto/format/xls97.py
+++ b/msoffcrypto/format/xls97.py
@@ -445,7 +445,7 @@ class _BIFFStream:
 class Xls97File(base.BaseOfficeFile):
     def __init__(self, file):
         self.file = file
-        ole = olefile.OleFileIO(file)    # closed in destructor
+        ole = olefile.OleFileIO(file)  # do not close this, would close file
         self.ole = ole
         self.format = "xls97"
         self.keyTypes = ['password']
@@ -460,9 +460,7 @@ class Xls97File(base.BaseOfficeFile):
         )
 
     def __del__(self):
-        """Destructor, closes opened olefile and stream."""
-        if hasattr(self, 'ole') and self.ole:
-            self.ole.close()
+        """Destructor, closes opened stream."""
         if hasattr(self, 'data') and self.data and self.data.workbook:
             self.data.workbook.close()
 

--- a/tests/test_file_handle.py
+++ b/tests/test_file_handle.py
@@ -1,0 +1,44 @@
+"""Check that given file handles are not closed."""
+
+
+import unittest
+from os.path import join, dirname
+
+from msoffcrypto import OfficeFile
+
+
+#: directory with input
+DATA_DIR = join(dirname(__file__), 'inputs')
+
+
+class FileHandleTest(unittest.TestCase):
+    """See module doc."""
+
+    def test_file_handle_open(self):
+        """Check that file handles are open after is_encrypted()."""
+        for suffix in 'doc', 'ppt', 'xls':
+            path = join(DATA_DIR, 'plain.' + suffix)
+
+            with open(path, 'rb') as file_handle:
+                ofile = OfficeFile(file_handle)
+
+                # do something with ofile
+                self.assertEqual(ofile.is_encrypted(), False)
+
+                # check that file handle is still open
+                self.assertFalse(file_handle.closed)
+
+                # destroy OfficeFile, calls destructor
+                del ofile
+
+                # check that file handle is still open
+                self.assertFalse(file_handle.closed)
+
+            # just for completeness:
+            # check that file handle is now closed
+            self.assertTrue(file_handle.closed)
+
+
+# if someone calls this as script, run unittests
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Correct for excessive closing of file handles

When creating the last PR (#39), I closed too much. I did not take into account that closing an OleFileIO also closes the file handle it was given in the constructor. If the caller of `OfficeFile` wanted to continue working the the file handle (which is her right), she was presented with "ValueError: seek of closed file".

Correct this here and create unittest to prevent this from happening again.
And since we are looking at file handles: also seek to 0 before checking for isOleFile()