### PR TITLE
Update RC4CryptoAPI_makekey 

### DIFF
--- a/msoffcrypto/method/rc4_cryptoapi.py
+++ b/msoffcrypto/method/rc4_cryptoapi.py
@@ -18,8 +18,8 @@ def _makekey(password, salt, keyLength, block, algIdHash=0x00008004):
     h0 = sha1(salt + password).digest()
     blockbytes = pack("<I", block)
     hfinal = sha1(h0 + blockbytes).digest()
-    if keyLength == 40:  # TODO
-        raise Exception("Not implemented")
+    if keyLength == 40:
+        key = hfinal[:5]+b'\x00'*11
     else:
         key = hfinal[:keyLength // 8]
     return key

--- a/msoffcrypto/method/rc4_cryptoapi.py
+++ b/msoffcrypto/method/rc4_cryptoapi.py
@@ -19,7 +19,7 @@ def _makekey(password, salt, keyLength, block, algIdHash=0x00008004):
     blockbytes = pack("<I", block)
     hfinal = sha1(h0 + blockbytes).digest()
     if keyLength == 40:
-        key = hfinal[:5]+b'\x00'*11
+        key = hfinal[:5] + b"\x00" * 11
     else:
         key = hfinal[:keyLength // 8]
     return key


### PR DESCRIPTION
Hello!

https://docs.microsoft.com/en-us/openspecs/office_file_formats/ms-offcrypto/12ec1195-af2d-44e6-8c73-003e79e635d5
keyLength is exactly 40 bits, the encryption key MUST be composed of the first 40 bits of Hfinal and 88 bits set to zero, creating a 128-bit key.