### PR TITLE
Use custom exceptions

### DIFF
--- a/msoffcrypto/__init__.py
+++ b/msoffcrypto/__init__.py
@@ -2,6 +2,8 @@ import olefile
 import zipfile
 import pkg_resources
 
+from . import exceptions
+
 __version__ = pkg_resources.get_distribution("msoffcrypto-tool").version
 
 
@@ -20,6 +22,23 @@ def OfficeFile(file):
         ...     officefile.keyTypes
         ('password', 'private_key', 'secret_key')
 
+        >>> with open("tests/inputs/example_password.docx", "rb") as f:
+        ...     officefile = OfficeFile(f)
+        ...     officefile.load_key(password="Password1234_", verify_password=True)
+
+        >>> with open("README.md", "rb") as f:
+        ...     officefile = OfficeFile(f)
+        Traceback (most recent call last):
+            ...
+        msoffcrypto.exceptions.FileFormatError: ...
+
+        >>> with open("tests/inputs/example_password.docx", "rb") as f:
+        ...     officefile = OfficeFile(f)
+        ...     officefile.load_key(password="0000", verify_password=True)
+        Traceback (most recent call last):
+            ...
+        msoffcrypto.exceptions.InvalidKeyError: ...
+
     Given file handle will not be closed, the file position will most certainly
     change.
     """
@@ -31,7 +50,7 @@ def OfficeFile(file):
 
         return OOXMLFile(file)
     else:
-        raise Exception("Unsupported file format")
+        raise exceptions.FileFormatError("Unsupported file format")
 
     # TODO: Make format specifiable by option in case of obstruction
     # Try this first; see https://github.com/nolze/msoffcrypto-tool/issues/17
@@ -58,4 +77,4 @@ def OfficeFile(file):
 
         return Ppt97File(file)
     else:
-        raise Exception("Unrecognized file format")
+        raise exceptions.FileFormatError("Unrecognized file format")

--- a/msoffcrypto/__main__.py
+++ b/msoffcrypto/__main__.py
@@ -7,6 +7,7 @@ import olefile
 
 from . import __version__
 from . import OfficeFile
+from . import exceptions
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -62,7 +63,7 @@ def main():
         return
 
     if not olefile.isOleFile(args.infile):
-        raise Exception("Not OLE file")
+        raise exceptions.FileFormatError("Not OLE file")
 
     file = OfficeFile(args.infile)
 

--- a/msoffcrypto/exceptions.py
+++ b/msoffcrypto/exceptions.py
@@ -1,0 +1,22 @@
+class FileFormatError(Exception):
+    """Raised when the format of given file is unsupported or unrecognized.
+    """
+    pass
+
+
+class ParseError(Exception):
+    """Raised when the file cannot be parsed correctly.
+    """
+    pass
+
+
+class DecryptionError(Exception):
+    """Raised when the file cannot be decrypted.
+    """
+    pass
+
+
+class InvalidKeyError(DecryptionError):
+    """Raised when the given password or key is incorrect or cannot be verified.
+    """
+    pass

--- a/msoffcrypto/format/ppt97.py
+++ b/msoffcrypto/format/ppt97.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 import olefile
 
+from .. import exceptions
 from . import base
 from .common import _parse_encryptionheader, _parse_encryptionverifier
 from ..method.rc4_cryptoapi import DocumentRC4CryptoAPI
@@ -518,6 +519,21 @@ def _parse_header_RC4CryptoAPI(encryptionInfo):
 
 
 class Ppt97File(base.BaseOfficeFile):
+    """Return a MS-PPT file object.
+
+    Examples:
+        >>> with open("tests/inputs/rc4cryptoapi_password.ppt", "rb") as f:
+        ...     officefile = Ppt97File(f)
+        ...     officefile.load_key(password="Password1234_")
+
+        >>> with open("tests/inputs/rc4cryptoapi_password.ppt", "rb") as f:
+        ...     officefile = Ppt97File(f)
+        ...     officefile.load_key(password="0000")
+        Traceback (most recent call last):
+            ...
+        msoffcrypto.exceptions.InvalidKeyError: ...
+    """
+
     def __init__(self, file):
         self.file = file
         ole = olefile.OleFileIO(file)  # do not close this, would close file
@@ -580,7 +596,7 @@ class Ppt97File(base.BaseOfficeFile):
             self.salt = info["salt"]
             self.keySize = info["keySize"]
         else:
-            raise Exception("Failed to verify password")
+            raise exceptions.InvalidKeyError("Failed to verify password")
 
     def decrypt(self, ofile):
         # Current User Stream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ cryptography = ">=2.3"
 olefile = ">=0.45"
 
 [tool.poetry.dev-dependencies]
-pytest = [{ version = ">=6.2.1", python = "^3.6" }, { version = "^4.6.11", python = "^2.7" }]
+pytest = [
+  { version = ">=6.2.1", python = "^3.6" },
+  { git = "https://github.com/nolze/pytest.git", branch = "4.6.x", python = "^2.7" },
+]
 black = { version = "^20.8b1", python = "^3.6" }
 coverage = { extras = ["toml"], version = "^5.3.1" }
 


### PR DESCRIPTION
This PR resolves #50 by introducing following custom exceptions in [msoffcrypto/exceptions.py](https://github.com/nolze/msoffcrypto-tool/compare/feature/exceptions?expand=1#diff-d4d91bd67effd739fa47dba99bf7130fb1123ea4c7533a42d597bf5a6ebc9341):

- `FileFormatError`,
- `ParseError` (uninteresting),
- `DecryptionError`,
- `InvalidKeyError` (inheriting `DecryptionError`).


/cc @cal97g and @decalage2, please let me know if you have any suggestions or comments.

