### PR TITLE
Use patched pytest for Python 2.7 (for a moment)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,10 @@ cryptography = ">=2.3"
 olefile = ">=0.45"
 
 [tool.poetry.dev-dependencies]
-pytest = [{ version = ">=6.2.1", python = "^3.6" }, { version = "^4.6.11", python = "^2.7" }]
+pytest = [
+  { version = ">=6.2.1", python = "^3.6" },
+  { git = "https://github.com/nolze/pytest.git", branch = "4.6.x", python = "^2.7" },
+]
 black = { version = "^20.8b1", python = "^3.6" }
 coverage = { extras = ["toml"], version = "^5.3.1" }
 


### PR DESCRIPTION
We must drop Python 2.7 support before long, anyway.