### PR TITLE
Never return None in ooxml's _parseinfo

### DIFF
--- a/msoffcrypto/format/ooxml.py
+++ b/msoffcrypto/format/ooxml.py
@@ -98,6 +98,7 @@ def _parseinfo(ole):
         return "standard", _parseinfo_standard(ole)
     elif versionMajor in [3, 4] and versionMinor == 3:  # Extensible
         raise exceptions.DecryptionError("Unsupported EncryptionInfo version (Extensible Encryption)")
+    raise exceptions.DecryptionError("Unsupported EncryptionInfo version ({}:{})".format(versionMajor, versionMinor))
 
 
 class OOXMLFile(base.BaseOfficeFile):


### PR DESCRIPTION
In the case where we are handling a corrupted file, the EncryptionInfo could be versionMajor 0 and versionMinor 0. In that case, the code ends up returning None, which then tries to get unpacked into two objects for self.type and self.info. By always throwing and exception, it should cover the case where the code doesn't handle the specified EncryptionInfo version.