### PR TITLE
Fix for incorrect key size with 0 length keySize var

### DIFF
--- a/msoffcrypto/format/common.py
+++ b/msoffcrypto/format/common.py
@@ -13,6 +13,7 @@ def _parse_encryptionheader(blob):
     (algId,) = unpack("<I", blob.read(4))
     (algIdHash,) = unpack("<I", blob.read(4))
     (keySize,) = unpack("<I", blob.read(4))
+    keySize = 40 if keySize == 0 else keySize
     (providerType,) = unpack("<I", blob.read(4))
     (reserved1,) = unpack("<I", blob.read(4))
     (reserved2,) = unpack("<I", blob.read(4))

--- a/msoffcrypto/format/common.py
+++ b/msoffcrypto/format/common.py
@@ -1,3 +1,4 @@
+import io
 import logging
 from struct import unpack
 
@@ -13,7 +14,6 @@ def _parse_encryptionheader(blob):
     (algId,) = unpack("<I", blob.read(4))
     (algIdHash,) = unpack("<I", blob.read(4))
     (keySize,) = unpack("<I", blob.read(4))
-    keySize = 40 if keySize == 0 else keySize
     (providerType,) = unpack("<I", blob.read(4))
     (reserved1,) = unpack("<I", blob.read(4))
     (reserved2,) = unpack("<I", blob.read(4))
@@ -50,3 +50,25 @@ def _parse_encryptionverifier(blob, algorithm):
         "encryptedVerifierHash": encryptedVerifierHash,
     }
     return verifier
+
+
+def _parse_header_RC4CryptoAPI(encryptionHeader):
+    flags = encryptionHeader.read(4)
+    (headerSize,) = unpack("<I", encryptionHeader.read(4))
+    logger.debug(headerSize)
+    blob = io.BytesIO(encryptionHeader.read(headerSize))
+    header = _parse_encryptionheader(blob)
+    logger.debug(header)
+    # NOTE: https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-offcrypto/36cfb17f-9b15-4a9b-911a-f401f60b3991
+    keySize = 0x00000028 if header["keySize"] == 0 else header["keySize"]
+
+    blob = io.BytesIO(encryptionHeader.read())
+    verifier = _parse_encryptionverifier(blob, "RC4")  # TODO: Fix (cf. ooxml.py)
+    logger.debug(verifier)
+    info = {
+        "salt": verifier["salt"],
+        "keySize": keySize,
+        "encryptedVerifier": verifier["encryptedVerifier"],
+        "encryptedVerifierHash": verifier["encryptedVerifierHash"],
+    }
+    return info

--- a/msoffcrypto/format/doc97.py
+++ b/msoffcrypto/format/doc97.py
@@ -9,7 +9,7 @@ import olefile
 
 from msoffcrypto import exceptions
 from msoffcrypto.format import base
-from msoffcrypto.format.common import _parse_encryptionheader, _parse_encryptionverifier
+from msoffcrypto.format.common import _parse_header_RC4CryptoAPI
 from msoffcrypto.method.rc4 import DocumentRC4
 from msoffcrypto.method.rc4_cryptoapi import DocumentRC4CryptoAPI
 
@@ -254,25 +254,6 @@ def _parse_header_RC4(encryptionHeader):
         "salt": salt,
         "encryptedVerifier": encryptedVerifier,
         "encryptedVerifierHash": encryptedVerifierHash,
-    }
-    return info
-
-
-def _parse_header_RC4CryptoAPI(encryptionHeader):
-    flags = encryptionHeader.read(4)
-    (headerSize,) = unpack("<I", encryptionHeader.read(4))
-    logger.debug(headerSize)
-    blob = io.BytesIO(encryptionHeader.read(headerSize))
-    header = _parse_encryptionheader(blob)
-    logger.debug(header)
-    blob = io.BytesIO(encryptionHeader.read())
-    verifier = _parse_encryptionverifier(blob, "RC4")  # TODO: Fix (cf. ooxml.py)
-    logger.debug(verifier)
-    info = {
-        "salt": verifier["salt"],
-        "keySize": header["keySize"],
-        "encryptedVerifier": verifier["encryptedVerifier"],
-        "encryptedVerifierHash": verifier["encryptedVerifierHash"],
     }
     return info
 

--- a/msoffcrypto/format/ppt97.py
+++ b/msoffcrypto/format/ppt97.py
@@ -9,7 +9,7 @@ import olefile
 
 from msoffcrypto import exceptions
 from msoffcrypto.format import base
-from msoffcrypto.format.common import _parse_encryptionheader, _parse_encryptionverifier
+from msoffcrypto.format.common import _parse_header_RC4CryptoAPI
 from msoffcrypto.method.rc4_cryptoapi import DocumentRC4CryptoAPI
 
 logger = logging.getLogger(__name__)
@@ -500,25 +500,6 @@ def construct_persistobjectdirectory(data):
                 persistobjectdirectory[entry.persistId + i] = offset
 
     return persistobjectdirectory
-
-
-def _parse_header_RC4CryptoAPI(encryptionInfo):
-    flags = encryptionInfo.read(4)
-    (headerSize,) = unpack("<I", encryptionInfo.read(4))
-    logger.debug(headerSize)
-    blob = io.BytesIO(encryptionInfo.read(headerSize))
-    header = _parse_encryptionheader(blob)
-    logger.debug(header)
-    blob = io.BytesIO(encryptionInfo.read())
-    verifier = _parse_encryptionverifier(blob, "RC4")  # TODO: Fix (cf. ooxml.py)
-    logger.debug(verifier)
-    info = {
-        "salt": verifier["salt"],
-        "keySize": header["keySize"],
-        "encryptedVerifier": verifier["encryptedVerifier"],
-        "encryptedVerifierHash": verifier["encryptedVerifierHash"],
-    }
-    return info
 
 
 class Ppt97File(base.BaseOfficeFile):

--- a/msoffcrypto/format/xls97.py
+++ b/msoffcrypto/format/xls97.py
@@ -6,7 +6,7 @@ import olefile
 
 from msoffcrypto import exceptions
 from msoffcrypto.format import base
-from msoffcrypto.format.common import _parse_encryptionheader, _parse_encryptionverifier
+from msoffcrypto.format.common import _parse_header_RC4CryptoAPI
 from msoffcrypto.method.rc4 import DocumentRC4
 from msoffcrypto.method.rc4_cryptoapi import DocumentRC4CryptoAPI
 from msoffcrypto.method.xor_obfuscation import DocumentXOR
@@ -382,25 +382,6 @@ def _parse_header_RC4(encryptionInfo):
         "salt": salt,
         "encryptedVerifier": encryptedVerifier,
         "encryptedVerifierHash": encryptedVerifierHash,
-    }
-    return info
-
-
-def _parse_header_RC4CryptoAPI(encryptionInfo):
-    flags = encryptionInfo.read(4)
-    (headerSize,) = unpack("<I", encryptionInfo.read(4))
-    logger.debug(headerSize)
-    blob = io.BytesIO(encryptionInfo.read(headerSize))
-    header = _parse_encryptionheader(blob)
-    logger.debug(header)
-    blob = io.BytesIO(encryptionInfo.read())
-    verifier = _parse_encryptionverifier(blob, "RC4")  # TODO: Fix (cf. ooxml.py)
-    logger.debug(verifier)
-    info = {
-        "salt": verifier["salt"],
-        "keySize": header["keySize"],
-        "encryptedVerifier": verifier["encryptedVerifier"],
-        "encryptedVerifierHash": verifier["encryptedVerifierHash"],
     }
     return info
 


### PR DESCRIPTION
I have found several ppt samples which don't have a proper keySize set.

Since 0 is an incorrect key size this change increases the chance that the file will still be readable.