### PR TITLE
Stream OOXML decryption to avoid buffering the whole payload

### DIFF
--- a/msoffcrypto/format/ooxml.py
+++ b/msoffcrypto/format/ooxml.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 import base64
 import io
 import logging
 import zipfile
+from collections.abc import Iterator
 from struct import unpack
+from typing import BinaryIO
 from xml.dom.minidom import parseString
 
 import olefile
@@ -15,6 +19,149 @@ from msoffcrypto.method.ecma376_standard import ECMA376Standard
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
+
+_ZIP_EOCD_SIGNATURE = b"PK\x05\x06"
+_ZIP_EOCD_SIZE = 22
+_ZIP_MAX_COMMENT_SIZE = 0xFFFF
+_ZIP_MAX_TAIL_SIZE = _ZIP_EOCD_SIZE + _ZIP_MAX_COMMENT_SIZE  # 22 + 65535 = 65557
+
+
+def _is_zipfile_tail(tail: bytes) -> bool:
+    """Return True if ``tail`` is the trailing bytes of a valid zip file.
+
+    ``zipfile.is_zipfile`` needs a seekable file and validates the
+    end-of-central-directory record found in the last ``_ZIP_MAX_TAIL_SIZE``
+    bytes.  This equivalent check only needs those trailing bytes, so a
+    decrypted stream can be validated without buffering the whole payload.
+    """
+    start = tail.rfind(_ZIP_EOCD_SIGNATURE)
+    if start < 0:
+        return False
+    record = tail[start : start + _ZIP_EOCD_SIZE]
+    if len(record) != _ZIP_EOCD_SIZE:
+        return False
+    (comment_size,) = unpack("<H", record[20:22])
+    return len(tail) - start >= _ZIP_EOCD_SIZE + comment_size
+
+
+def _decrypt_stream_to(outfile: BinaryIO, chunks: Iterator[bytes]) -> bytes:
+    """Write ``chunks`` to ``outfile`` and return the trailing bytes written.
+
+    Keeps only the last ``_ZIP_MAX_TAIL_SIZE`` bytes so peak memory stays
+    constant regardless of the payload size.
+    """
+    tail = bytearray()
+    for chunk in chunks:
+        outfile.write(chunk)
+        tail.extend(chunk)
+        if len(tail) > _ZIP_MAX_TAIL_SIZE:
+            del tail[: len(tail) - _ZIP_MAX_TAIL_SIZE]
+    return bytes(tail)
+
+
+class _OleStreamReader:
+    """Read an OLE stream lazily, one sector at a time.
+
+    ``olefile.OleFileIO.openstream`` eagerly loads the entire stream into a
+    BytesIO (see the ``FIXME`` on ``olefile.OleStream``), which dominates
+    decryption peak memory for large ``EncryptedPackage`` streams.  This reader
+    follows the FAT chain on demand while still exposing the ``seek``/``read``
+    interface the decryption routines expect.
+    """
+
+    def __init__(self, ole: olefile.OleFileIO, name: str) -> None:
+        sid = ole._find(name)
+        entry = ole.direntries[sid]
+        self._ole = ole
+        self._size = entry.size
+        self._start_sect = entry.isectStart
+        self._sectorsize = ole.sectorsize
+        self._fat = ole.fat
+        self._pos = 0
+        # Cursor: the FAT sector ``_cur_sect`` holds stream offset ``_cur_offset``.
+        self._cur_sect = entry.isectStart
+        self._cur_offset = 0
+
+    def __enter__(self) -> _OleStreamReader:
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        return False
+
+    def tell(self) -> int:
+        return self._pos
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        if whence == 0:
+            pos = offset
+        elif whence == 1:
+            pos = self._pos + offset
+        elif whence == 2:
+            pos = self._size + offset
+        else:
+            raise ValueError("invalid whence ({})".format(whence))
+        if pos < 0:
+            pos = 0
+        self._pos = pos
+        return pos
+
+    def _advance_to(self, stream_offset: int) -> None:
+        if stream_offset < self._cur_offset:
+            # Rewind. The decryption routines only seek backwards to 0, so this
+            # is cheap in practice.
+            self._cur_sect = self._start_sect
+            self._cur_offset = 0
+        while stream_offset >= self._cur_offset + self._sectorsize:
+            next_sect = self._fat[self._cur_sect] & 0xFFFFFFFF
+            if not (0 <= next_sect < len(self._fat)):
+                break
+            self._cur_sect = next_sect
+            self._cur_offset += self._sectorsize
+
+    def read(self, n: int = -1) -> bytes:
+        if n is None or n < 0:
+            n = self._size - self._pos
+        n = min(n, self._size - self._pos)
+        if n <= 0:
+            return b""
+
+        self._advance_to(self._pos)
+        parts = []
+        remaining = n
+        while remaining > 0:
+            if not (0 <= self._cur_sect < len(self._fat)):
+                break
+            offset_in_sector = self._pos - self._cur_offset
+            if offset_in_sector >= self._sectorsize:
+                break
+            self._ole.fp.seek(
+                self._sectorsize * (self._cur_sect + 1) + offset_in_sector
+            )
+            want = min(remaining, self._sectorsize - offset_in_sector)
+            data = self._ole.fp.read(want)
+            if not data:
+                break
+            parts.append(data)
+            self._pos += len(data)
+            remaining -= len(data)
+            if self._pos >= self._cur_offset + self._sectorsize:
+                self._cur_sect = self._fat[self._cur_sect] & 0xFFFFFFFF
+                self._cur_offset += self._sectorsize
+        return b"".join(parts)
+
+
+def _open_stream(ole: olefile.OleFileIO, name: str) -> BinaryIO:
+    """Open ``name`` for streaming reads, falling back for mini-FAT streams.
+
+    Large streams live in the regular FAT and can be read lazily; small streams
+    use the mini-FAT, which ``_OleStreamReader`` does not implement, so delegate
+    those (tiny) streams to ``olefile``.
+    """
+    sid = ole._find(name)
+    entry = ole.direntries[sid]
+    if entry.size >= ole.minisectorcutoff:
+        return _OleStreamReader(ole, name)
+    return ole.openstream(name)
 
 
 def _is_ooxml(file):
@@ -256,8 +403,8 @@ class OOXMLFile(base.BaseOfficeFile):
         msoffcrypto.exceptions.DecryptionError: Document is not encrypted
         """
         if self.type == "agile":
-            with self.file.openstream("EncryptedPackage") as stream:
-                if verify_integrity:
+            if verify_integrity:
+                with self.file.openstream("EncryptedPackage") as stream:
                     verified = ECMA376Agile.verify_integrity(
                         self.secret_key,
                         self.info["keyDataSalt"],
@@ -272,24 +419,29 @@ class OOXMLFile(base.BaseOfficeFile):
                             "Payload integrity verification failed"
                         )
 
-                obuf = ECMA376Agile.decrypt(
-                    self.secret_key,
-                    self.info["keyDataSalt"],
-                    self.info["keyDataHashAlgorithm"],
-                    stream,
+            with _open_stream(self.file, "EncryptedPackage") as stream:
+                tail = _decrypt_stream_to(
+                    outfile,
+                    ECMA376Agile.decrypt_stream(
+                        self.secret_key,
+                        self.info["keyDataSalt"],
+                        self.info["keyDataHashAlgorithm"],
+                        stream,
+                    ),
                 )
-            outfile.write(obuf)
         elif self.type == "standard":
-            with self.file.openstream("EncryptedPackage") as stream:
-                obuf = ECMA376Standard.decrypt(self.secret_key, stream)
-            outfile.write(obuf)
+            with _open_stream(self.file, "EncryptedPackage") as stream:
+                tail = _decrypt_stream_to(
+                    outfile,
+                    ECMA376Standard.decrypt_stream(self.secret_key, stream),
+                )
         elif self.type == "plain":
             raise exceptions.DecryptionError("Document is not encrypted")
         else:
             raise exceptions.DecryptionError("Unsupported encryption method")
 
         # If the file is successfully decrypted, there must be a valid OOXML file, i.e. a valid zip file
-        if not zipfile.is_zipfile(io.BytesIO(obuf)):
+        if not _is_zipfile_tail(tail):
             raise exceptions.InvalidKeyError(
                 "The file could not be decrypted with this password"
             )

--- a/msoffcrypto/method/ecma376_agile.py
+++ b/msoffcrypto/method/ecma376_agile.py
@@ -6,8 +6,10 @@ import hmac
 import io
 import logging
 import secrets
+from collections.abc import Iterator
 from hashlib import sha1, sha256, sha384, sha512
 from struct import pack, unpack
+from typing import BinaryIO
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -203,7 +205,7 @@ class ECMA376Agile:
         return encryption_key
 
     @staticmethod
-    def decrypt(key, keyDataSalt, hashAlgorithm, ibuf):
+    def decrypt(key: bytes, keyDataSalt: bytes, hashAlgorithm: str, ibuf: BinaryIO) -> bytes:
         r"""
         Return decrypted data.
 
@@ -211,11 +213,23 @@ class ECMA376Agile:
             >>> keyDataSalt = b'\x8f\xc7x"+P\x8d\xdcL\xe6\x8c\xdd\x15<\x16\xb4'
             >>> hashAlgorithm = 'SHA512'
         """
+        return b"".join(
+            ECMA376Agile.decrypt_stream(key, keyDataSalt, hashAlgorithm, ibuf)
+        )
+
+    @staticmethod
+    def decrypt_stream(
+        key: bytes, keyDataSalt: bytes, hashAlgorithm: str, ibuf: BinaryIO
+    ) -> Iterator[bytes]:
+        r"""
+        Yield decrypted data in chunks.
+
+        Reads ``ibuf`` in ``SEGMENT_LENGTH``-byte segments and yields each
+        decrypted segment instead of buffering the whole payload in memory.
+        """
         # NOTE: See https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-offcrypto/9e61da63-8ddb-4c0a-b25d-f85d990f44c8
         SEGMENT_LENGTH = 4096
         hashCalc = _get_hash_func(hashAlgorithm)
-
-        obuf = io.BytesIO()
 
         # NOTE: See https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-offcrypto/b60c8b35-2db2-4409-8710-59d88a793f83
         ibuf.seek(0)
@@ -235,12 +249,11 @@ class ECMA376Agile:
             # TODO: Check
             if remaining < len(dec):
                 dec = dec[:remaining]
-            obuf.write(dec)
+            yield dec
             remaining -= len(dec)
             # TODO: Check if this is needed
             if remaining <= 0:
                 break
-        return obuf.getvalue()  # return obuf.getbuffer()
 
     @staticmethod
     def encrypt(key, ibuf, salt_value=None, spin_count=100000):

--- a/msoffcrypto/method/ecma376_standard.py
+++ b/msoffcrypto/method/ecma376_standard.py
@@ -1,7 +1,9 @@
-import io
+import functools
 import logging
+from collections.abc import Iterator
 from hashlib import sha1
 from struct import pack, unpack
+from typing import BinaryIO
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -9,27 +11,47 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+SEGMENT_LENGTH = 4096
+
 
 class ECMA376Standard:
     def __init__(self):
         pass
 
     @staticmethod
-    def decrypt(key, ibuf):
+    def decrypt(key: bytes, ibuf: BinaryIO) -> bytes:
         r"""
         Return decrypted data.
 
         """
-        obuf = io.BytesIO()
+        return b"".join(ECMA376Standard.decrypt_stream(key, ibuf))
+
+    @staticmethod
+    def decrypt_stream(key: bytes, ibuf: BinaryIO) -> Iterator[bytes]:
+        r"""
+        Yield decrypted data in chunks.
+
+        Only the first 4 bytes (``totalSize``) describe the real length; the
+        encrypted data is padded to the AES block size, so exactly ``totalSize``
+        plaintext bytes are yielded.
+        """
         totalSize = unpack("<I", ibuf.read(4))[0]
         logger.debug("totalSize: {}".format(totalSize))
         ibuf.seek(8)
         aes = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
         decryptor = aes.decryptor()
-        x = ibuf.read()
-        dec = decryptor.update(x) + decryptor.finalize()
-        obuf.write(dec[:totalSize])
-        return obuf.getvalue()  # return obuf.getbuffer()
+        remaining = totalSize
+        for buf in iter(functools.partial(ibuf.read, SEGMENT_LENGTH), b""):
+            dec = decryptor.update(buf)
+            if remaining < len(dec):
+                dec = dec[:remaining]
+            yield dec
+            remaining -= len(dec)
+            if remaining <= 0:
+                break
+        dec = decryptor.finalize()
+        if remaining > 0 and dec:
+            yield dec[:remaining]
 
     @staticmethod
     def verifykey(key, encryptedVerifier, encryptedVerifierHash):

--- a/tests/test_ooxml_streaming.py
+++ b/tests/test_ooxml_streaming.py
@@ -1,0 +1,96 @@
+"""Tests for streaming OOXML decryption.
+
+The streaming entry points should produce byte-for-byte the same output as the
+original, buffering-based implementations, without requiring a seekable output
+destination.
+"""
+
+import unittest
+from os.path import dirname, join
+
+from msoffcrypto import exceptions
+from msoffcrypto.format.ooxml import OOXMLFile
+from msoffcrypto.method.ecma376_agile import ECMA376Agile
+from msoffcrypto.method.ecma376_standard import ECMA376Standard
+
+DATA_DIR = join(dirname(__file__), "inputs")
+OUTPUT_DIR = join(dirname(__file__), "outputs")
+
+PASSWORD = "Password1234_"
+
+
+class _Sink:
+    """A write-only destination, similar to ``sys.stdout.buffer``."""
+
+    def __init__(self):
+        self.data = bytearray()
+
+    def write(self, buf):
+        self.data.extend(buf)
+        return len(buf)
+
+
+class OOXMLStreamingTest(unittest.TestCase):
+    def test_agile_stream_matches_decrypt(self):
+        with open(join(DATA_DIR, "example_password.docx"), "rb") as f:
+            officefile = OOXMLFile(f)
+            officefile.load_key(password=PASSWORD)
+
+            with officefile.file.openstream("EncryptedPackage") as stream:
+                expected = ECMA376Agile.decrypt(
+                    officefile.secret_key,
+                    officefile.info["keyDataSalt"],
+                    officefile.info["keyDataHashAlgorithm"],
+                    stream,
+                )
+            with officefile.file.openstream("EncryptedPackage") as stream:
+                actual = b"".join(
+                    ECMA376Agile.decrypt_stream(
+                        officefile.secret_key,
+                        officefile.info["keyDataSalt"],
+                        officefile.info["keyDataHashAlgorithm"],
+                        stream,
+                    )
+                )
+
+        self.assertEqual(actual, expected)
+
+    def test_standard_stream_matches_decrypt(self):
+        with open(join(DATA_DIR, "ecma376standard_password.docx"), "rb") as f:
+            officefile = OOXMLFile(f)
+            officefile.load_key(password=PASSWORD)
+
+            with officefile.file.openstream("EncryptedPackage") as stream:
+                expected = ECMA376Standard.decrypt(officefile.secret_key, stream)
+            with officefile.file.openstream("EncryptedPackage") as stream:
+                actual = b"".join(
+                    ECMA376Standard.decrypt_stream(officefile.secret_key, stream)
+                )
+
+        self.assertEqual(actual, expected)
+
+    def test_decrypt_to_write_only_stream(self):
+        with open(join(OUTPUT_DIR, "example.docx"), "rb") as f:
+            expected = f.read()
+
+        with open(join(DATA_DIR, "example_password.docx"), "rb") as f:
+            officefile = OOXMLFile(f)
+            officefile.load_key(password=PASSWORD)
+
+            sink = _Sink()
+            officefile.decrypt(sink)
+
+        self.assertEqual(bytes(sink.data), expected)
+
+    def test_decrypt_wrong_password_raises(self):
+        with open(join(DATA_DIR, "example_password.docx"), "rb") as f:
+            officefile = OOXMLFile(f)
+            officefile.load_key(password="incorrect")
+
+            sink = _Sink()
+            with self.assertRaises(exceptions.InvalidKeyError):
+                officefile.decrypt(sink)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes https://github.com/nolze/msoffcrypto-tool/issues/101

### Problem

`OOXMLFile.decrypt()` materialized the entire decrypted OOXML package in memory and copied it several times. Both `ECMA376Agile.decrypt()` and `ECMA376Standard.decrypt()` accumulated output in a `BytesIO` and returned a second full copy, and `ooxml.py` copied the result again into a `BytesIO` just to run `zipfile.is_zipfile()`. Peak RSS was ~4–5× the input size.

### Changes

- **Agile** (`msoffcrypto/method/ecma376_agile.py`): extracted the existing 4096-byte segment loop into a streaming generator `ECMA376Agile.decrypt_stream(...)`. `decrypt(...)` is now a thin wrapper returning `b"".join(...)`, preserving the old API.
- **Standard** (`msoffcrypto/method/ecma376_standard.py`): added `ECMA376Standard.decrypt_stream(...)`, which feeds AES-ECB incrementally in chunks and yields exactly `totalSize` plaintext bytes. `decrypt(...)` remains as a wrapper.
- **Validation** (`msoffcrypto/format/ooxml.py`): replaced `zipfile.is_zipfile(io.BytesIO(obuf))` with a tail-only end-of-central-directory check (`_is_zipfile_tail`) that keeps just the last 65,557 bytes while streaming, so the payload is never copied for validation. The same `InvalidKeyError` is raised on failure.
- **OLE stream read** (`msoffcrypto/format/ooxml.py`): `olefile.openstream()` eagerly loads the whole `EncryptedPackage` stream into a `BytesIO` (see olefile's own `FIXME`), which dominated the remaining memory. Added `_OleStreamReader` to follow the FAT chain and read one sector at a time, with a fallback to `openstream()` for small/mini-FAT streams.

### Backward compatibility

- `OOXMLFile.decrypt(outfile)` and the top-level `OfficeFile.decrypt(outfile)` keep the same signatures.
- `ECMA376Agile.decrypt(...)` and `ECMA376Standard.decrypt(...)` still return `bytes`.

### Tests

- Added `tests/test_ooxml_streaming.py`: verifies the streaming output is byte-identical to the buffered `decrypt()`, works with a non-seekable output destination, and that a wrong password still raises `InvalidKeyError`. No large binary fixtures are committed.
- Full suite passes (`pytest`).

### Memory

Measured with `/usr/bin/time -l` on a 1.79 GB agile-encrypted `.ppsx`:

- before: ~4.95 GiB peak RSS
- after: ~0.88 GiB peak RSS

The remaining ~0.88 GiB comes from `olefile.OleFileIO.__init__` parsing the OLE structure (its `loadfat` builds the FAT with `array + array` in a loop), which runs before any decryption and is outside this patch. The streaming decrypt path itself now stays at a small constant buffer plus one 4096-byte segment.

### Out of scope

`verify_integrity=True` (the agile HMAC path) still reads the full stream once, because it needs the entire payload to compute the HMAC. It is opt-in and left unchanged.
